### PR TITLE
Fix broken conda installer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -49,7 +49,7 @@ CMD [ "sleep", "infinity" ]
 # Based on https://github.com/ContinuumIO/docker-images/blob/master/miniconda3/debian/Dockerfile.
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh \
     && mkdir -p /opt \
-    && sh miniconda.sh -b -p /opt/conda \
+    && bash miniconda.sh -b -p /opt/conda \
     && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
     && find /opt/conda/ -follow -type f -name '*.a' -delete \
     && find /opt/conda/ -follow -type f -name '*.js.map' -delete \


### PR DESCRIPTION
The miniconda installer now needs to be run with bash. See https://github.com/conda/conda/issues/10431. We could pin the conda version, but probably not worth it for this repo