### PR TITLE
Adopt snake casing update

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -89,7 +89,7 @@ RUN mkdir -p /home/vscode/.local/share/CMakeTools \
     && chown vscode:conda /home/vscode/.local/share/CMakeTools/cmake-tools-kits.json
 
 # Install the yardl tool
-ARG YARDL_VERSION=0.2.1
+ARG YARDL_VERSION=0.2.2
 RUN wget --quiet "https://github.com/microsoft/yardl/releases/download/v${YARDL_VERSION}/yardl_${YARDL_VERSION}_linux_x86_64.tar.gz" \
     && tar -xzf "yardl_${YARDL_VERSION}_linux_x86_64.tar.gz" \
     && mv yardl "/opt/conda/envs/${CONDA_ENVIRONMENT_NAME}/bin/" \

--- a/cpp/mrd/ismrmrd_to_mrd.cc
+++ b/cpp/mrd/ismrmrd_to_mrd.cc
@@ -392,17 +392,17 @@ mrd::EncodingLimitsType convert(ISMRMRD::EncodingLimits &e)
 
     if (e.kspace_encoding_step_0)
     {
-        encodingLimits.kspace_encoding_step0 = convert(*e.kspace_encoding_step_0);
+        encodingLimits.kspace_encoding_step_0 = convert(*e.kspace_encoding_step_0);
     }
 
     if (e.kspace_encoding_step_1)
     {
-        encodingLimits.kspace_encoding_step1 = convert(*e.kspace_encoding_step_1);
+        encodingLimits.kspace_encoding_step_1 = convert(*e.kspace_encoding_step_1);
     }
 
     if (e.kspace_encoding_step_2)
     {
-        encodingLimits.kspace_encoding_step2 = convert(*e.kspace_encoding_step_2);
+        encodingLimits.kspace_encoding_step_2 = convert(*e.kspace_encoding_step_2);
     }
 
     if (e.average)
@@ -442,42 +442,42 @@ mrd::EncodingLimitsType convert(ISMRMRD::EncodingLimits &e)
 
     if (e.user[0])
     {
-        encodingLimits.user0 = convert(*e.user[0]);
+        encodingLimits.user_0 = convert(*e.user[0]);
     }
 
     if (e.user[1])
     {
-        encodingLimits.user1 = convert(*e.user[1]);
+        encodingLimits.user_1 = convert(*e.user[1]);
     }
 
     if (e.user[2])
     {
-        encodingLimits.user2 = convert(*e.user[2]);
+        encodingLimits.user_2 = convert(*e.user[2]);
     }
 
     if (e.user[3])
     {
-        encodingLimits.user3 = convert(*e.user[3]);
+        encodingLimits.user_3 = convert(*e.user[3]);
     }
 
     if (e.user[4])
     {
-        encodingLimits.user4 = convert(*e.user[4]);
+        encodingLimits.user_4 = convert(*e.user[4]);
     }
 
     if (e.user[5])
     {
-        encodingLimits.user5 = convert(*e.user[5]);
+        encodingLimits.user_5 = convert(*e.user[5]);
     }
 
     if (e.user[6])
     {
-        encodingLimits.user6 = convert(*e.user[6]);
+        encodingLimits.user_6 = convert(*e.user[6]);
     }
 
     if (e.user[7])
     {
-        encodingLimits.user7 = convert(*e.user[7]);
+        encodingLimits.user_7 = convert(*e.user[7]);
     }
 
     return encodingLimits;
@@ -543,8 +543,8 @@ mrd::TrajectoryDescriptionType convert(ISMRMRD::TrajectoryDescription &t)
 mrd::AccelerationFactorType convert(ISMRMRD::AccelerationFactor &a)
 {
     mrd::AccelerationFactorType accelerationFactor;
-    accelerationFactor.kspace_encoding_step1 = a.kspace_encoding_step_1;
-    accelerationFactor.kspace_encoding_step2 = a.kspace_encoding_step_2;
+    accelerationFactor.kspace_encoding_step_1 = a.kspace_encoding_step_1;
+    accelerationFactor.kspace_encoding_step_2 = a.kspace_encoding_step_2;
     return accelerationFactor;
 }
 
@@ -878,7 +878,7 @@ mrd::UserParametersType convert(ISMRMRD::UserParameters &u)
 
     for (auto &p : u.userParameterBase64)
     {
-        userParameters.user_parameter_base64.push_back(convert_userbase64(p));
+        userParameters.user_parameter_base_64.push_back(convert_userbase64(p));
     }
 
     return userParameters;
@@ -985,8 +985,8 @@ mrd::Header convert(ISMRMRD::IsmrmrdHeader &hdr)
 mrd::EncodingCounters convert(ISMRMRD::EncodingCounters &e)
 {
     mrd::EncodingCounters encodingCounters;
-    encodingCounters.kspace_encode_step1 = e.kspace_encode_step_1;
-    encodingCounters.kspace_encode_step2 = e.kspace_encode_step_2;
+    encodingCounters.kspace_encode_step_1 = e.kspace_encode_step_1;
+    encodingCounters.kspace_encode_step_2 = e.kspace_encode_step_2;
     encodingCounters.average = e.average;
     encodingCounters.slice = e.slice;
     encodingCounters.contrast = e.contrast;

--- a/cpp/mrd/mrd_phantom.cc
+++ b/cpp/mrd/mrd_phantom.cc
@@ -212,8 +212,8 @@ int main(int argc, char **argv)
       {
         a.flags |= static_cast<uint64_t>(AcquisitionFlags::kLastInEncodeStep1);
       }
-      a.idx.kspace_encode_step1 = line;
-      a.idx.kspace_encode_step2 = 0;
+      a.idx.kspace_encode_step_1 = line;
+      a.idx.kspace_encode_step_2 = 0;
       a.idx.slice = 0;
       a.idx.repetition = r;
       a.data = xt::view(kspace, xt::all(), 0, line, xt::all());

--- a/cpp/mrd/mrd_stream_recon.cc
+++ b/cpp/mrd/mrd_stream_recon.cc
@@ -64,7 +64,7 @@ int main()
       }
 
       // copy the data into the buffer
-      xt::view(buffer, xt::all(), a.idx.kspace_encode_step2.value(), a.idx.kspace_encode_step1.value(), xt::all()) = xt::xarray<std::complex<float>>(a.data);
+      xt::view(buffer, xt::all(), a.idx.kspace_encode_step_2.value(), a.idx.kspace_encode_step_1.value(), xt::all()) = xt::xarray<std::complex<float>>(a.data);
 
       // if this is the last line, we need to write the buffer
       if (a.flags.HasFlags(mrd::AcquisitionFlags::kLastInEncodeStep1) || a.flags.HasFlags(mrd::AcquisitionFlags::kLastInSlice))

--- a/cpp/mrd/mrd_to_ismrmrd.cc
+++ b/cpp/mrd/mrd_to_ismrmrd.cc
@@ -374,19 +374,19 @@ ISMRMRD::EncodingLimits convert(mrd::EncodingLimitsType &encodingLimit)
 {
     ISMRMRD::EncodingLimits el;
 
-    if (encodingLimit.kspace_encoding_step0)
+    if (encodingLimit.kspace_encoding_step_0)
     {
-        el.kspace_encoding_step_0 = convert(*encodingLimit.kspace_encoding_step0);
+        el.kspace_encoding_step_0 = convert(*encodingLimit.kspace_encoding_step_0);
     }
 
-    if (encodingLimit.kspace_encoding_step1)
+    if (encodingLimit.kspace_encoding_step_1)
     {
-        el.kspace_encoding_step_1 = convert(*encodingLimit.kspace_encoding_step1);
+        el.kspace_encoding_step_1 = convert(*encodingLimit.kspace_encoding_step_1);
     }
 
-    if (encodingLimit.kspace_encoding_step2)
+    if (encodingLimit.kspace_encoding_step_2)
     {
-        el.kspace_encoding_step_2 = convert(*encodingLimit.kspace_encoding_step2);
+        el.kspace_encoding_step_2 = convert(*encodingLimit.kspace_encoding_step_2);
     }
 
     if (encodingLimit.average)
@@ -424,44 +424,44 @@ ISMRMRD::EncodingLimits convert(mrd::EncodingLimitsType &encodingLimit)
         el.segment = convert(*encodingLimit.segment);
     }
 
-    if (encodingLimit.user0)
+    if (encodingLimit.user_0)
     {
-        el.user[0] = convert(*encodingLimit.user0);
+        el.user[0] = convert(*encodingLimit.user_0);
     }
 
-    if (encodingLimit.user1)
+    if (encodingLimit.user_1)
     {
-        el.user[1] = convert(*encodingLimit.user1);
+        el.user[1] = convert(*encodingLimit.user_1);
     }
 
-    if (encodingLimit.user2)
+    if (encodingLimit.user_2)
     {
-        el.user[2] = convert(*encodingLimit.user2);
+        el.user[2] = convert(*encodingLimit.user_2);
     }
 
-    if (encodingLimit.user3)
+    if (encodingLimit.user_3)
     {
-        el.user[3] = convert(*encodingLimit.user3);
+        el.user[3] = convert(*encodingLimit.user_3);
     }
 
-    if (encodingLimit.user4)
+    if (encodingLimit.user_4)
     {
-        el.user[4] = convert(*encodingLimit.user4);
+        el.user[4] = convert(*encodingLimit.user_4);
     }
 
-    if (encodingLimit.user5)
+    if (encodingLimit.user_5)
     {
-        el.user[5] = convert(*encodingLimit.user5);
+        el.user[5] = convert(*encodingLimit.user_5);
     }
 
-    if (encodingLimit.user6)
+    if (encodingLimit.user_6)
     {
-        el.user[6] = convert(*encodingLimit.user6);
+        el.user[6] = convert(*encodingLimit.user_6);
     }
 
-    if (encodingLimit.user7)
+    if (encodingLimit.user_7)
     {
-        el.user[7] = convert(*encodingLimit.user7);
+        el.user[7] = convert(*encodingLimit.user_7);
     }
 
     return el;
@@ -527,8 +527,8 @@ ISMRMRD::TrajectoryDescription convert(mrd::TrajectoryDescriptionType &t)
 ISMRMRD::AccelerationFactor convert(mrd::AccelerationFactorType &a)
 {
     ISMRMRD::AccelerationFactor accelerationFactor;
-    accelerationFactor.kspace_encoding_step_1 = a.kspace_encoding_step1;
-    accelerationFactor.kspace_encoding_step_2 = a.kspace_encoding_step2;
+    accelerationFactor.kspace_encoding_step_1 = a.kspace_encoding_step_1;
+    accelerationFactor.kspace_encoding_step_2 = a.kspace_encoding_step_2;
     return accelerationFactor;
 }
 
@@ -829,7 +829,7 @@ ISMRMRD::UserParameters convert(mrd::UserParametersType &u)
         userParameters.userParameterString.push_back(convert(p));
     }
 
-    for (auto &p : u.user_parameter_base64)
+    for (auto &p : u.user_parameter_base_64)
     {
         userParameters.userParameterBase64.push_back(convert_userbase64(p));
     }
@@ -946,18 +946,18 @@ ISMRMRD::IsmrmrdHeader convert(mrd::Header &hdr)
 ISMRMRD::EncodingCounters convert(mrd::EncodingCounters &e)
 {
     ISMRMRD::EncodingCounters encodingCounters;
-    if (e.kspace_encode_step1)
+    if (e.kspace_encode_step_1)
     {
-        encodingCounters.kspace_encode_step_1 = *e.kspace_encode_step1;
+        encodingCounters.kspace_encode_step_1 = *e.kspace_encode_step_1;
     }
     else
     {
         encodingCounters.kspace_encode_step_1 = 0;
     }
 
-    if (e.kspace_encode_step2)
+    if (e.kspace_encode_step_2)
     {
-        encodingCounters.kspace_encode_step_2 = *e.kspace_encode_step2;
+        encodingCounters.kspace_encode_step_2 = *e.kspace_encode_step_2;
     }
     else
     {
@@ -1090,8 +1090,8 @@ ISMRMRD::Acquisition convert(mrd::Acquisition &acq)
     hdr.patient_table_position[0] = acq.patient_table_position[0];
     hdr.patient_table_position[1] = acq.patient_table_position[1];
     hdr.patient_table_position[2] = acq.patient_table_position[2];
-    hdr.idx.kspace_encode_step_1 = acq.idx.kspace_encode_step1 ? *acq.idx.kspace_encode_step1 : 0;
-    hdr.idx.kspace_encode_step_2 = acq.idx.kspace_encode_step2 ? *acq.idx.kspace_encode_step2 : 0;
+    hdr.idx.kspace_encode_step_1 = acq.idx.kspace_encode_step_1 ? *acq.idx.kspace_encode_step_1 : 0;
+    hdr.idx.kspace_encode_step_2 = acq.idx.kspace_encode_step_2 ? *acq.idx.kspace_encode_step_2 : 0;
     hdr.idx.average = acq.idx.average ? *acq.idx.average : 0;
     hdr.idx.slice = acq.idx.slice ? *acq.idx.slice : 0;
     hdr.idx.contrast = acq.idx.contrast ? *acq.idx.contrast : 0;

--- a/justfile
+++ b/justfile
@@ -1,13 +1,15 @@
 set shell := ['bash', '-ceuo', 'pipefail']
 
-ensure-build-dir:
+@default: test
+
+@ensure-build-dir:
     mkdir -p cpp/build
 
-configure: ensure-build-dir
+@configure: ensure-build-dir
     cd cpp/build; \
     cmake -GNinja  ..
 
-build: configure
+@build: configure
     cd cpp/build && ninja
 
 @convert-xsd:
@@ -15,7 +17,7 @@ build: configure
     python utils/xsd-to-yardl.py ismrmrd.xsd > model/mrd_header.yml
     rm ismrmrd.xsd
 
-generate:
+@generate:
     cd model && yardl generate
 
 @converter-roundtrip-test:
@@ -32,4 +34,4 @@ generate:
     ismrmrd_hdf5_to_stream -i roundtrip.h5 --use-stdout | ismrmrd_stream_recon_cartesian_2d --use-stdin --use-stdout | ./ismrmrd_to_mrd | ./mrd_to_ismrmrd > recon_rountrip.bin; \
     diff direct.bin roundtrip.bin & diff recon_direct.bin recon_rountrip.bin
 
-test: generate build converter-roundtrip-test
+@test: generate build converter-roundtrip-test


### PR DESCRIPTION
Update to Yardl x0.2.2, which changes the way snake casing is computed for identifiers around numbers.