### PR TITLE
Pinning the build number of pugixml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - ninja=1.11.0
   - nlohmann_json=3.11.2
   - python=3.9.15
+  - pugixml=1.11.4=*_0
   - shellcheck=0.8.0
   - valgrind=3.18.1
   - xmlschema=2.2.3

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - ninja=1.11.0
   - nlohmann_json=3.11.2
   - python=3.9.15
-  - pugixml=1.11.4=*_0
+  - pugixml=1.11.4=h9c3ff4c_0
   - shellcheck=0.8.0
   - valgrind=3.18.1
   - xmlschema=2.2.3


### PR DESCRIPTION
The PugiXML conda package was updated (https://github.com/conda-forge/pugixml-feedstock/pull/22) and it switched from static to dynamic library without changing the version of the package, so we need to pin the build number. 